### PR TITLE
Implement path and assocPath

### DIFF
--- a/src/assocPath/index.js
+++ b/src/assocPath/index.js
@@ -1,0 +1,5 @@
+// TODO: fix this
+const assocPath = ([key, ...keys], val, obj) =>
+  !keys.length ? { ...obj, [key]: val } : assocPath(keys, { ...obj, [key]: val }, obj[key] || {});
+
+export default assocPath;

--- a/src/assocPath/index.spec.js
+++ b/src/assocPath/index.spec.js
@@ -1,0 +1,23 @@
+import assert from 'assert';
+
+import assocPath from '.';
+
+describe('path', () => {
+  it('works', () => {
+    const tested = assocPath(['a', 'b', 'c'], 42, { a: { b: { c: 0 } } });
+    const expected = { a: { b: { c: 42 } } };
+    assert.deepStrictEqual(tested, expected, 'Should return `{a: {b: {c: 42}}}`');
+  });
+
+  it('should preserve all other values not in path', () => {
+    const tested = assocPath(['a', 'b', 'c'], 42, { a: { b: { c: 0 }, d: 10 } });
+    const expected = { a: { b: { c: 42 }, d: 10 } };
+    assert.deepStrictEqual(tested, expected, 'Should return `{a: {b: {c: 42}, d:10}}`');
+  });
+
+  it('should override any missing or non-object keys in path', () => {
+    const tested = assocPath(['a', 'b', 'c'], 42, { a: 5 });
+    const expected = { a: { b: { c: 42 } } };
+    assert.deepStrictEqual(tested, expected, 'Should return `{a: {b: {c: 42}}}`');
+  });
+});

--- a/src/constant/index.js
+++ b/src/constant/index.js
@@ -9,6 +9,6 @@
  * const fn = constant(1);
  * fn(); // 1
  */
-const constant = arg => () => arg;
+const constant = x => () => x;
 
 export default constant;

--- a/src/path/index.js
+++ b/src/path/index.js
@@ -1,0 +1,15 @@
+/**
+ * Retrieve the value at a given path
+ *
+ * @func
+ * @param {Array} path - Array with given path to extract
+ * @param {*} obj - The object from which to extract the value
+ * @returns {*} - The value of the given path
+ *
+ * @example
+ * path(['a', 'b'], {a: {b: 2}}); // 2
+ * path(['a', 'b'], {c: {b: 2}}); // undefined
+ */
+const path = ([key, ...keys], obj) => (!keys.length ? obj[key] : path(keys, obj[key] || {}));
+
+export default path;

--- a/src/path/index.spec.js
+++ b/src/path/index.spec.js
@@ -1,0 +1,17 @@
+import assert from 'assert';
+
+import path from '.';
+
+describe('path', () => {
+  it('works', () => {
+    const tested = path(['a', 'b'], { a: { b: 2 } });
+    const expected = 2;
+    assert.equal(tested, expected, 'Should return 2');
+  });
+
+  it('works without happy path', () => {
+    const tested = path(['a', 'b'], { c: { b: 2 } });
+    const expected = undefined;
+    assert.equal(tested, expected, 'Should return `undefined`');
+  });
+});


### PR DESCRIPTION
In the building of my own lenses I realised I needed both the `path`  and the `assocPath` functions, the first one was easy but the second... not so much, any ideas to fix `assocPath` so that it passes the tests? It's so close to being correct...